### PR TITLE
fix: QR scanner

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,13 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['react-native-reanimated/plugin', 'babel-plugin-transform-typescript-metadata', ['@babel/plugin-proposal-decorators', { legacy: true }]],
+  plugins: [
+    'babel-plugin-transform-typescript-metadata',
+    ['@babel/plugin-proposal-decorators', { legacy: true }],
+    [
+      'react-native-reanimated/plugin',
+      {
+        globals: ['__scanCodes'],
+      },
+    ],
+  ],
 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  * @format
  */
-
+import 'react-native-reanimated';
 import { AppRegistry } from 'react-native';
 import App from './App';
 import { name as appName } from './app.json';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lodash": "^4.17.21",
     "react": "18.1.0",
     "react-native": "0.70.6",
+    "react-native-camera": "^4.2.1",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.8.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,11 @@
     "lodash": "^4.17.21",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-camera": "^4.2.1",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.8.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-pager-view": "^5.4.9",
     "react-native-permissions": "^3.6.1",
-    "react-native-qrcode-scanner": "^1.5.4",
     "react-native-qrcode-svg": "^6.1.1",
     "react-native-reanimated": "^2.2.4",
     "react-native-safe-area-context": "3.3.2",
@@ -45,8 +43,10 @@
     "react-native-svg": "^12.1.1",
     "react-native-tab-view": "^3.1.1",
     "react-native-toast-message": "^2.0.1",
+    "react-native-vision-camera": "^2.15.2",
     "typeorm": "^0.2.38",
-    "typesafe-web3": "^0.0.17"
+    "typesafe-web3": "^0.0.17",
+    "vision-camera-code-scanner": "^0.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -4,7 +4,7 @@ import { HomeScreen } from '../screens/home/HomeScreen';
 import { SendCoinScreen } from '../screens/home/SendCoinScreen';
 import { ReceiveCoinScreen } from '../screens/home/ReceiveCoinScreen';
 import { WalletDetailsScreen } from '../screens/home/WalletDetailsScreen';
-// import { ScannerScreen } from '../screens/home/ScannerScreen';
+import { ScannerScreen } from '../screens/home/ScannerScreen';
 import { WalletModel } from '../data/entities/wallet';
 import { CreateWalletScreen } from '../screens/home/CreateWalletScreen';
 import { WalletSettingsScreen } from '../screens/home/WalletSettingsScreen';
@@ -39,7 +39,7 @@ export function HomeStackNavigator() {
       <HomeStack.Screen name="HomeScreen" component={HomeScreen} options={{ title: 'Home', headerRight: () => <HomeScreenHeaderRight /> }} />
       <HomeStack.Screen name="CreateWalletScreen" component={CreateWalletScreen} options={{ title: 'Create' }} />
       <HomeStack.Screen name="SendCoinScreen" component={SendCoinScreen} options={{ title: 'Send' }} />
-      {/* <HomeStack.Screen name="ScannerScreen" component={ScannerScreen} options={{ title: 'Scan' }} /> */}
+      <HomeStack.Screen name="ScannerScreen" component={ScannerScreen} options={{ title: 'Scan' }} />
       <HomeStack.Screen name="ReceiveCoinScreen" component={ReceiveCoinScreen} options={{ title: 'Receive' }} />
       <HomeStack.Screen name="WalletScreen" component={WalletDetailsScreen} options={{ title: 'Details' }} />
       <HomeStack.Screen name="WalletSettingsScreen" component={WalletSettingsScreen} options={{ title: 'Settings' }} />

--- a/src/screens/home/ScannerScreen.tsx
+++ b/src/screens/home/ScannerScreen.tsx
@@ -1,24 +1,40 @@
-import * as React from 'react';
-import { SafeAreaView, View } from 'react-native';
+import React from 'react';
+import { SafeAreaView, View, StyleSheet } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useNavigation } from '@react-navigation/core';
 import { HomeStackParamList } from '../../navigation/HomeStackNavigator';
-import QRCodeScanner from 'react-native-qrcode-scanner';
-import { BarCodeReadEvent } from 'react-native-camera';
 
+import { Camera, useCameraDevices } from 'react-native-vision-camera';
+import { useScanBarcodes, BarcodeFormat } from 'vision-camera-code-scanner';
 export const ScannerScreen = () => {
+  const [hasPermission, setHasPermission] = React.useState(false);
+  const devices = useCameraDevices();
+  const device = devices.back;
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
   const navigator = useNavigation<homeScreenProp>();
 
-  const onSuccess = (readEvent: BarCodeReadEvent) => {
-    navigator.navigate('SendCoinScreen', { address: readEvent.data });
+  const onSuccess = (readEvent: string) => {
+    navigator.navigate('SendCoinScreen', { address: readEvent });
   };
-
+  const [frameProcessor, barcodes] = useScanBarcodes([BarcodeFormat.QR_CODE], {
+    checkInverted: true,
+  });
+  React.useEffect(() => {
+    (async () => {
+      const status = await Camera.requestCameraPermission();
+      setHasPermission(status === 'authorized');
+    })();
+  }, []);
   return (
     <SafeAreaView style={GlobalStyles.flex}>
       <View style={GlobalStyles.centerCenter}>
-        <QRCodeScanner vibrate={false} onRead={onSuccess} />
+        {device != null && hasPermission && (
+          <>
+            <Camera style={StyleSheet.absoluteFill} device={device} isActive={true} frameProcessor={frameProcessor} frameProcessorFps={5} />
+            {barcodes.map(barcode => onSuccess(barcode.displayValue))}
+          </>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7343,6 +7343,13 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-native-camera@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-4.2.1.tgz#caf74081f055e89d7e9b0cd5108965d808c60e90"
+  integrity sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-native-cli-bump-version@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-native-cli-bump-version/-/react-native-cli-bump-version-1.5.0.tgz#f078532aef307e5645975e44cf26c397b2f62625"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,7 +1472,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@react-native-async-storage/async-storage@^1.13.4", "@react-native-async-storage/async-storage@^1.15.17":
+"@react-native-async-storage/async-storage@^1.15.17":
   version "1.17.11"
   resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
   integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
@@ -7236,7 +7236,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7343,13 +7343,6 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-native-camera@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-4.2.1.tgz#caf74081f055e89d7e9b0cd5108965d808c60e90"
-  integrity sha512-+Vkql24PFYQfsPRznJCvPwJQfyzCnjlcww/iZ4Ej80bgivKjL9eU0IMQIXp4yi6XCrKi4voWXxIDPMupQZKeIQ==
-  dependencies:
-    prop-types "^15.6.2"
-
 react-native-cli-bump-version@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-native-cli-bump-version/-/react-native-cli-bump-version-1.5.0.tgz#f078532aef307e5645975e44cf26c397b2f62625"
@@ -7420,24 +7413,10 @@ react-native-pager-view@^5.4.9:
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.4.25.tgz#cd639d5387a7f3d5581b55a33c5faa1cbc200f97"
   integrity sha512-3drrYwaLat2fYszymZe3nHMPASJ4aJMaxiejfA1V5SK3OygYmdtmV2u5prX7TnjueJzGSyyaCYEr2JlrRt4YPg==
 
-react-native-permissions@^2.0.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-2.2.2.tgz#3d2a63f6b7d6be52fc86e30f77412a9566283028"
-  integrity sha512-ihf4shQDSX5Oo9ChQXb9kr13mmyyNem5MaEvOpr3dCjhBOBWyEMztXm9/uPK1Qg5PsNpaYLa1KpcPZDCw87LXg==
-
 react-native-permissions@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.6.1.tgz#73adcc1cef8cd57a9ef167b4507405f4ff5749c4"
   integrity sha512-fzPpPQXeD34inUccqtoResSwYubfrwUguP4qrVUUv8+KSMjYSaHGoS5HaIJLZHlN9gO+TvLJZ2L5ZljTsb6qnQ==
-
-react-native-qrcode-scanner@^1.5.4:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/react-native-qrcode-scanner/-/react-native-qrcode-scanner-1.5.5.tgz#0d20101712715da108742a2bbbd0397569031b01"
-  integrity sha512-il79uStkFqUvofqXJQfOL30qgQyU17MUKxj7IGHv6oT2OxIY/vutTwuPPDbsivtv0yTMHP4dGx/79oys4eAuNw==
-  dependencies:
-    "@react-native-async-storage/async-storage" "^1.13.4"
-    prop-types "^15.5.10"
-    react-native-permissions "^2.0.2"
 
 react-native-qrcode-svg@^6.1.1:
   version "6.1.2"
@@ -7497,6 +7476,11 @@ react-native-toast-message@^2.0.1:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.1.5.tgz#550acb9c6c0f1ee49c6b57b65a56d34e297eb723"
   integrity sha512-mk3rELtBEhrhWBCN6CTaw0gypgL9ZNauX3xx1LUs4uee9vc0pVsghrKxO57vroUCcNL2hDeZSLJWdQNMCkGeaQ==
+
+react-native-vision-camera@^2.15.2:
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.15.2.tgz#96a17c8b4e557df317734897853a861e0cfbc3ed"
+  integrity sha512-pkVj0r2nbZaj3+bB9CGPNistCUyoCgS2SmawzugrZs5oMlFWlgZYuJj+6s3Q98xTGgV/8/ST0njohB6soDi0VA==
 
 react-native@0.70.6:
   version "0.70.6"
@@ -8942,6 +8926,11 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vision-camera-code-scanner@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/vision-camera-code-scanner/-/vision-camera-code-scanner-0.2.0.tgz#8adc0694319a17f6a95f6dfacc02ab7ac29b4742"
+  integrity sha512-H5hVkXfbIcGdg9YlhuS8Y/xDX5e32Vo6eK5FyDQsE9AGVjlqEHMmSLHZg7BX8UUm4ADmiAZc8wzc4n8TUqGr0g==
 
 vlq@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
[issue-58](https://github.com/akroma-project/akroma-wallet-mobile/issues/58)

## Description
  - In the ScreenScanner View we have QRCodeScanner. This package is breaking the application.

## Reason
  - The library react-native-camera is deprecated.
## Solution
  - Replace the deprecated library for **react-native-vision-camera** and **vision-camera-code-scanner**

## To test
  - Go to wallet list.(If you don't have one, create it)
  - Select one.
  - Select button with up arrow.
  - Select camera icon.
  - Scan QR of address wallet.

## Expected

  - The wallet must to be displayed in the input.
  
closes #58 