### PR TITLE
feat: remove action button from details screen

### DIFF
--- a/src/components/DetailsScreenHeaderRight.tsx
+++ b/src/components/DetailsScreenHeaderRight.tsx
@@ -1,0 +1,48 @@
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { useNavigation } from '@react-navigation/core';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { Icon } from '@ui-kitten/components';
+import React from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TouchableOpacity } from 'react-native';
+import GlobalStyles from '../constants/GlobalStyles';
+import { WalletModel } from '../data/entities/wallet';
+import { HomeStackParamList } from '../navigation/HomeStackNavigator';
+interface options {
+  title: string;
+  screen: string;
+  params?: { wallet: WalletModel };
+}
+
+export const DetailsScreenHeaderRight = () => {
+  type homeScreenProp = StackNavigationProp<HomeStackParamList, 'WalletScreen'>;
+  const navigator = useNavigation<homeScreenProp>();
+  const { showActionSheetWithOptions } = useActionSheet();
+  return (
+    <TouchableOpacity
+      onPress={() =>
+        showActionSheetWithOptions(
+          {
+            options: ['Receive Coin', 'Send Coin', 'Wallet Settings'],
+            cancelButtonIndex: 99,
+            showSeparators: true,
+          },
+          async (index: number) => {
+            if (index === 0) {
+              navigator.navigate('ReceiveCoinScreen');
+            }
+            if (index === 1) {
+              navigator.navigate('SendCoinScreen');
+            }
+            if (index === 2) {
+              navigator.navigate('WalletSettingsScreen', {
+                wallet: JSON.parse(await AsyncStorage.getItem('walletSelected')),
+              });
+            }
+          },
+        )
+      }>
+      <Icon name="menu-outline" style={GlobalStyles.iconRight} fill="#000000" />
+    </TouchableOpacity>
+  );
+};

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -13,7 +13,7 @@ import { ImportWalletKeystore } from '../screens/home/ImportWalletKeystore';
 import { ImportWalletPrivateKey } from '../screens/home/ImportWalletPrivateKey';
 import { ImportWalletSeedPhrase } from '../screens/home/ImportWalletSeedPhrase';
 import { ImportWalletWatch } from '../screens/home/ImportWalletWatch';
-
+import { DetailsScreenHeaderRight } from '../components/DetailsScreenHeaderRight';
 export type HomeStackParamList = {
   HomeScreen: { update: boolean } | undefined;
   WalletScreen: { wallet: WalletModel };
@@ -41,7 +41,7 @@ export function HomeStackNavigator() {
       <HomeStack.Screen name="SendCoinScreen" component={SendCoinScreen} options={{ title: 'Send' }} />
       <HomeStack.Screen name="ScannerScreen" component={ScannerScreen} options={{ title: 'Scan' }} />
       <HomeStack.Screen name="ReceiveCoinScreen" component={ReceiveCoinScreen} options={{ title: 'Receive' }} />
-      <HomeStack.Screen name="WalletScreen" component={WalletDetailsScreen} options={{ title: 'Details' }} />
+      <HomeStack.Screen name="WalletScreen" component={WalletDetailsScreen} options={{ title: 'Details', headerRight: () => <DetailsScreenHeaderRight /> }} />
       <HomeStack.Screen name="WalletSettingsScreen" component={WalletSettingsScreen} options={{ title: 'Settings' }} />
       <HomeStack.Screen name="ImportWalletKeystore" component={ImportWalletKeystore} options={{ title: 'Import Keystore' }} />
       <HomeStack.Screen name="ImportWalletPrivateKey" component={ImportWalletPrivateKey} options={{ title: 'Import Private Key' }} />

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -11,6 +11,7 @@ import { WalletModel } from '../../data/entities/wallet';
 import { WalletContext } from '../../providers/WalletProvider';
 import RNPermissions, { NotificationsResponse, Permission, PERMISSIONS, PermissionStatus } from 'react-native-permissions';
 import { ImageOverlay } from '../../extra/image-overlay.component';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const HomeScreen = () => {
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
@@ -65,9 +66,9 @@ export const HomeScreen = () => {
     await loadWallets();
   };
 
-  const onWalletPress = (wallet: WalletModel) => {
+  const onWalletPress = async (wallet: WalletModel) => {
+    await AsyncStorage.setItem('walletSelected', JSON.stringify(wallet));
     navigator.navigate('WalletScreen', { wallet: wallet });
-    console.debug(wallet.address);
   };
 
   const renderWalletRight = (item: WalletModel) => <Text>{item.lastBalance?.toString()}</Text>;

--- a/src/screens/home/WalletDetailsScreen.tsx
+++ b/src/screens/home/WalletDetailsScreen.tsx
@@ -7,7 +7,6 @@ import { Card, Text } from '@ui-kitten/components';
 import { useDatabaseConnection } from '../../data/connection';
 import { WalletModel } from '../../data/entities/wallet';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { WalletActionButtons } from '../../components/WalletActionButtons';
 
 export const WalletDetailsScreen = ({ route }: { route: any }) => {
   const { walletsRepository } = useDatabaseConnection();
@@ -64,9 +63,6 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
             <Text>{state.wallet.address}</Text>
           </TouchableOpacity>
         </Card>
-        <View style={GlobalStyles.actions}>
-          <WalletActionButtons wallet={state.wallet} />
-        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/screens/home/WalletSettingsScreen.tsx
+++ b/src/screens/home/WalletSettingsScreen.tsx
@@ -20,10 +20,8 @@ export const WalletSettingsScreen = ({ route }: { route: any }) => {
   const { removeWallet, setActive, state } = useContext(WalletContext);
   const [displayExport, setDisplayExport] = useState(false);
   const wallet: WalletModel = route.params.wallet;
-
   const [refreshing] = useState(false);
   const onRefresh = React.useCallback(() => {}, []);
-
   useEffect(() => {
     setActive(wallet.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/screens/wallets/WalletsScreen.tsx
+++ b/src/screens/wallets/WalletsScreen.tsx
@@ -9,6 +9,7 @@ import { Text, ListItem } from '@ui-kitten/components';
 import _ from 'lodash';
 import { WalletModel } from '../../data/entities/wallet';
 import { WalletContext } from '../../providers/WalletProvider';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const WalletsScreen = () => {
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
@@ -28,9 +29,9 @@ export const WalletsScreen = () => {
     await loadWallets();
   };
 
-  const onWalletPress = (wallet: WalletModel) => {
+  const onWalletPress = async (wallet: WalletModel) => {
+    await AsyncStorage.setItem('walletSelected', JSON.stringify(wallet));
     navigator.navigate('WalletScreen', { wallet: wallet });
-    console.debug(wallet.address);
   };
 
   const renderWalletRight = (item: WalletModel) => <Text>{item.lastBalance?.toString()}</Text>;


### PR DESCRIPTION
[issue-33](https://github.com/akroma-project/akroma-wallet-mobile/issues/33)

## Description
  - the action buttons on the wallet details are buttons at the bottom, this is inconsistent with the way the home page works.

## To do
  - Add a component like HomeScreenHeaderRight for WalletDetailsScreenHeaderRight.
  - Add the actions to the showActionSheetWithOptions
  - Remove the buttons from the page.

closes #33 