### PR TITLE
Feat/issue 69

### DIFF
--- a/src/screens/home/WalletDetailsScreen.tsx
+++ b/src/screens/home/WalletDetailsScreen.tsx
@@ -15,8 +15,9 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
   const { walletsRepository } = useDatabaseConnection();
   console.debug(route.params.wallet.id);
   const { updateBalance, setActive, state } = useContext(WalletContext);
-  type homeScreenProp = StackNavigationProp<HomeStackParamList, 'WalletScreen'>;
-  const navigator = useNavigation<homeScreenProp>();
+
+  type detailScreenProp = StackNavigationProp<HomeStackParamList, 'WalletScreen'>;
+  const navigator = useNavigation<detailScreenProp>();
 
   const wallet: WalletModel = route.params.wallet;
 
@@ -44,6 +45,7 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
     });
 
     return unsubscribe;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigator]);
 
   const onCopyAddress = () => {

--- a/src/screens/home/WalletDetailsScreen.tsx
+++ b/src/screens/home/WalletDetailsScreen.tsx
@@ -3,15 +3,20 @@ import { RefreshControl, SafeAreaView, ScrollView, TouchableOpacity, View } from
 import GlobalStyles from '../../constants/GlobalStyles';
 import { WalletContext } from '../../providers/WalletProvider';
 import { useContext, useEffect, useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import { HomeStackParamList } from '../../navigation/HomeStackNavigator';
 import { Card, Text } from '@ui-kitten/components';
 import { useDatabaseConnection } from '../../data/connection';
 import { WalletModel } from '../../data/entities/wallet';
 import Clipboard from '@react-native-clipboard/clipboard';
+import { StackNavigationProp } from '@react-navigation/stack';
 
 export const WalletDetailsScreen = ({ route }: { route: any }) => {
   const { walletsRepository } = useDatabaseConnection();
   console.debug(route.params.wallet.id);
   const { updateBalance, setActive, state } = useContext(WalletContext);
+  type homeScreenProp = StackNavigationProp<HomeStackParamList, 'WalletScreen'>;
+  const navigator = useNavigation<homeScreenProp>();
 
   const wallet: WalletModel = route.params.wallet;
 
@@ -34,9 +39,12 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
   }
 
   useEffect(() => {
-    init();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet.id]);
+    const unsubscribe = navigator.addListener('focus', async () => {
+      await init();
+    });
+
+    return unsubscribe;
+  }, [navigator]);
 
   const onCopyAddress = () => {
     Clipboard.setString(wallet.address);

--- a/src/screens/home/WalletDetailsScreen.tsx
+++ b/src/screens/home/WalletDetailsScreen.tsx
@@ -16,20 +16,24 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
   const wallet: WalletModel = route.params.wallet;
 
   const [refreshing] = useState(false);
-  const onRefresh = React.useCallback(() => {}, []);
+  const onRefresh = async () => {
+    await init();
+  };
+
+  async function init() {
+    setActive(wallet.id);
+    console.debug('wallet-screen: useEffect: update called');
+    const previous = wallet.lastBalance;
+    const updated = await updateBalance(wallet.id);
+
+    if (updated.lastBalance !== previous) {
+      console.debug(`old: ${previous} new: ${updated.lastBalance}`);
+      console.debug('useEffect: updating database with new blance');
+      await walletsRepository.update(updated);
+    }
+  }
 
   useEffect(() => {
-    async function init() {
-      setActive(wallet.id);
-      console.debug('wallet-screen: useEffect: update called');
-      const previous = wallet.lastBalance;
-      const updated = await updateBalance(wallet.id);
-      if (updated.lastBalance !== previous) {
-        console.debug(`old: ${previous} new: ${updated.lastBalance}`);
-        console.debug('useEffect: updating database with new blance');
-        await walletsRepository.update(updated);
-      }
-    }
     init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wallet.id]);

--- a/src/screens/wallets/WalletsScreen.tsx
+++ b/src/screens/wallets/WalletsScreen.tsx
@@ -14,7 +14,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export const WalletsScreen = () => {
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
   const navigator = useNavigation<homeScreenProp>();
-  const { state, loadWallets } = useContext(WalletContext);
+  const { state, loadWallets, refreshWallets } = useContext(WalletContext);
 
   useEffect(() => {
     async function init() {
@@ -26,6 +26,7 @@ export const WalletsScreen = () => {
 
   const [refreshing] = React.useState(false);
   const onRefresh = async () => {
+    await refreshWallets();
     await loadWallets();
   };
 


### PR DESCRIPTION
[issue-69](https://github.com/akroma-project/akroma-wallet-mobile/issues/69)
## Description
  - Currently, the list of wallets only updates once the user clicks in a wallet detail, even if you refresh the list of wallets their balance doesn't update to the current balance.
  - When you send coins and come back to the wallet detail, the balance doesn't update

## Solution
  -  Make a context provider method to refresh the wallets balance and it's called In the list of wallets when you refresh.
  -  In wallet details there is a focus event listener to update balance when you come back to wallet detail from sendcoin screen or other