### PR TITLE
Export keystore file to Icloud drive

### DIFF
--- a/ios/AkromaWallet-Bridging-Header.h
+++ b/ios/AkromaWallet-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/AkromaWallet.xcodeproj/project.pbxproj
+++ b/ios/AkromaWallet.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		1FAA95D48CD9F06027EEB3D2 /* libPods-AkromaWallet-AkromaWalletTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 75629D2380C7F781E24D5BBD /* libPods-AkromaWallet-AkromaWalletTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		846614B52952EB3B006962A4 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846614B42952EB3B006962A4 /* File.swift */; };
 		84732A13292D2E5000C0FA14 /* main.jsbundle in Resources */ = {isa = PBXBuildFile; fileRef = 84732A12292D2E4F00C0FA14 /* main.jsbundle */; };
 /* End PBXBuildFile section */
 
@@ -41,7 +42,10 @@
 		6C97AB639B58BBB4B15BBE30 /* Pods-AkromaWallet-AkromaWalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AkromaWallet-AkromaWalletTests.debug.xcconfig"; path = "Target Support Files/Pods-AkromaWallet-AkromaWalletTests/Pods-AkromaWallet-AkromaWalletTests.debug.xcconfig"; sourceTree = "<group>"; };
 		75629D2380C7F781E24D5BBD /* libPods-AkromaWallet-AkromaWalletTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AkromaWallet-AkromaWalletTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AkromaWallet/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		846614B32952EB3A006962A4 /* AkromaWallet-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AkromaWallet-Bridging-Header.h"; sourceTree = "<group>"; };
+		846614B42952EB3B006962A4 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		84732A12292D2E4F00C0FA14 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		84B8ED2F295268AD00A55DA9 /* AkromaWallet.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AkromaWallet.entitlements; path = AkromaWallet/AkromaWallet.entitlements; sourceTree = "<group>"; };
 		B09D8DD40348B58B19CFB22F /* libPods-AkromaWallet.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AkromaWallet.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0A881CF5CF3F2B244570E2A /* Pods-AkromaWallet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AkromaWallet.debug.xcconfig"; path = "Target Support Files/Pods-AkromaWallet/Pods-AkromaWallet.debug.xcconfig"; sourceTree = "<group>"; };
 		D00AAFFCFCFDA5787532823F /* Pods-AkromaWallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AkromaWallet.release.xcconfig"; path = "Target Support Files/Pods-AkromaWallet/Pods-AkromaWallet.release.xcconfig"; sourceTree = "<group>"; };
@@ -88,6 +92,7 @@
 		13B07FAE1A68108700A75B9A /* AkromaWallet */ = {
 			isa = PBXGroup;
 			children = (
+				84B8ED2F295268AD00A55DA9 /* AkromaWallet.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -118,6 +123,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				846614B42952EB3B006962A4 /* File.swift */,
 				84732A12292D2E4F00C0FA14 /* main.jsbundle */,
 				13B07FAE1A68108700A75B9A /* AkromaWallet */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
@@ -125,6 +131,7 @@
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				E233CBF5F47BEE60B243DCF8 /* Pods */,
+				846614B32952EB3A006962A4 /* AkromaWallet-Bridging-Header.h */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -210,7 +217,7 @@
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						LastSwiftMigration = 1120;
+						LastSwiftMigration = 1420;
 					};
 				};
 			};
@@ -410,6 +417,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				846614B52952EB3B006962A4 /* File.swift in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,6 +493,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = AkromaWallet/AkromaWallet.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = S7F2AX9XNQ;
 				ENABLE_BITCODE = NO;
@@ -502,6 +513,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.AkromaWallet;
 				PRODUCT_NAME = AkromaWallet;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "AkromaWallet-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -515,6 +528,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = AkromaWallet/AkromaWallet.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = S7F2AX9XNQ;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
@@ -531,6 +547,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactjs.native.example.AkromaWallet;
 				PRODUCT_NAME = AkromaWallet;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "AkromaWallet-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/ios/AkromaWallet/AkromaWallet.entitlements
+++ b/ios/AkromaWallet/AkromaWallet.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.org.reactjs.native.example.AkromaWallet</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.org.reactjs.native.example.AkromaWallet</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
+</plist>

--- a/ios/AkromaWallet/Info.plist
+++ b/ios/AkromaWallet/Info.plist
@@ -68,5 +68,18 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSUbiquitousContainers</key>
+    <dict>
+        <key>iCloud.org.reactjs.native.example.AkromaWallet</key>
+        <dict>
+            <key>NSUbiquitousContainerIsDocumentScopePublic</key>
+            <true/>
+            <key>NSUbiquitousContainerName</key>
+            <string>AkromaWallet</string>
+			<key>NSUbiquitousContainerSupportedFolderLevels</key>
+			<string>Any</string>
+        </dict>
+    </dict>
 </dict>
+
 </plist>

--- a/ios/File.swift
+++ b/ios/File.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  AkromaWallet
+//
+//  Created by admin on 21/12/22.
+//
+
+import Foundation

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "18.1.0",
     "react-native": "0.70.6",
     "react-native-camera": "^4.2.1",
+    "react-native-cloud-store": "^0.9.1",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.8.0",

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -149,6 +149,10 @@ const GlobalStyles = StyleSheet.create({
     marginTop: 10,
     marginHorizontal: 5,
   },
+  exportModalBtn: {
+    marginTop: 15,
+    marginHorizontal: '15%',
+  },
 });
 
 export default GlobalStyles;

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -147,6 +147,7 @@ const GlobalStyles = StyleSheet.create({
   },
   exportBtn: {
     marginTop: 10,
+    marginHorizontal: 5,
   },
 });
 

--- a/src/screens/home/WalletSettingsScreen.tsx
+++ b/src/screens/home/WalletSettingsScreen.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { useContext, useEffect, useState } from 'react';
+import * as CloudStore from 'react-native-cloud-store';
 import { RefreshControl, SafeAreaView, ScrollView, TouchableOpacity, View, Platform } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { GDrive, MimeTypes } from '@robinbobin/react-native-google-drive-api-wrapper';
+import { defaultICloudContainerPath } from 'react-native-cloud-store';
 
 import { StackNavigationProp } from '@react-navigation/stack';
 import { HomeStackParamList } from '../../navigation/HomeStackNavigator';
@@ -76,6 +78,23 @@ export const WalletSettingsScreen = ({ route }: { route: any }) => {
       });
   };
 
+  const exportToIcloud = async () => {
+    const isAvailable = await CloudStore.isICloudAvailable();
+    const fileName = getKeystoreFileName();
+    const filePathForWrite = `${defaultICloudContainerPath}/Documents/${fileName}.json`;
+
+    if (isAvailable) {
+      try {
+        await CloudStore.writeFile(filePathForWrite, wallet.encrypted, { override: true });
+        console.debug('file uploaded to Icloud drive');
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      console.debug('You should login with your apple id');
+    }
+  };
+
   const exportToGoogleDrive = async () => {
     const fileName = getKeystoreFileName();
     const platformSetup = Platform.OS === 'android' ? { scopes: ['https://www.googleapis.com/auth/drive.file'] } : { iosClientId: GOOGLESIGNIN_IOS_CLIENTID };
@@ -115,6 +134,9 @@ export const WalletSettingsScreen = ({ route }: { route: any }) => {
             <Button onPress={() => downloadKeystore()}>Download keystore file</Button>
             <Button style={GlobalStyles.exportBtn} onPress={() => exportToGoogleDrive()}>
               Export to Google drive
+            </Button>
+            <Button style={GlobalStyles.exportBtn} onPress={() => exportToIcloud()}>
+              Export to Icloud Drive
             </Button>
           </>
         )}

--- a/src/screens/home/WalletSettingsScreen.tsx
+++ b/src/screens/home/WalletSettingsScreen.tsx
@@ -131,13 +131,18 @@ export const WalletSettingsScreen = ({ route }: { route: any }) => {
           <>
             <Input style={GlobalStyles.input} disabled={true} value={wallet.pin} label="Password" accessoryRight={(props: any) => CopyIcon(props, wallet.pin)} />
             <Input style={GlobalStyles.input} disabled={true} value={wallet.encrypted} label="Keystore" accessoryRight={(props: any) => CopyIcon(props, wallet.encrypted)} />
-            <Button onPress={() => downloadKeystore()}>Download keystore file</Button>
+            <Button style={GlobalStyles.exportBtn} onPress={() => downloadKeystore()}>
+              Download to File system
+            </Button>
             <Button style={GlobalStyles.exportBtn} onPress={() => exportToGoogleDrive()}>
               Export to Google drive
             </Button>
-            <Button style={GlobalStyles.exportBtn} onPress={() => exportToIcloud()}>
-              Export to Icloud Drive
-            </Button>
+
+            {Platform.OS === 'ios' && (
+              <Button style={GlobalStyles.exportBtn} onPress={() => exportToIcloud()}>
+                Export to Icloud Drive
+              </Button>
+            )}
           </>
         )}
         {/* <View style={GlobalStyles.actions}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7379,6 +7379,11 @@ react-native-cli-bump-version@^1.3.0:
   resolved "https://registry.yarnpkg.com/react-native-cli-bump-version/-/react-native-cli-bump-version-1.5.0.tgz#f078532aef307e5645975e44cf26c397b2f62625"
   integrity sha512-B7eHE5gpVfc5Py90rU+cZsPEbaiz6wsFjxZrPbsKw1oyk/04Ae72ipQbAl/Y8FYK5AcvkyYf/DwQkTcDkKOEPA==
 
+react-native-cloud-store@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/react-native-cloud-store/-/react-native-cloud-store-0.9.1.tgz#47c8d9055817ee5f6c1811d6073d76a05d399f2b"
+  integrity sha512-fQG+8yZUU1l43+b//eAvu8bbdApiC+baZmNDJcW8KY3CHtDXkt1sr0bN6rpBmD0ZiiGKralGblkgBban9bUbtg==
+
 react-native-codegen@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.7.tgz#86651c5c5fec67a8077ef7f4e36f7ed459043e14"


### PR DESCRIPTION
[issue-73](https://github.com/akroma-project/akroma-wallet-mobile/issues/73)

## Description
- Users can export their wallet keystore file to their Icloud drive.

## To test
  1. Go to wallet
  2. Press the top right button.
  3. Select Wallet Settings.
  4. Press the top right button.
  5. Select export
  6. Select Export to Icloud drive button which is only visible in IOS devices

<img width="352" alt="Captura de Pantalla 2022-12-22 a la(s) 10 27 11" src="https://user-images.githubusercontent.com/50288507/209178862-0a2ab368-6f85-4259-b831-3ea3eb70c827.png">
<img width="352" alt="Captura de Pantalla 2022-12-22 a la(s) 10 27 11" src="https://user-images.githubusercontent.com/50288507/209179670-aa1ab1d7-7ecb-4a14-be7b-7935a8a20c96.png">


