### PR TITLE
fix: transaction History

### DIFF
--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -64,6 +64,7 @@ const WalletProvider = (props: serverProviderProps) => {
     if (wallet === undefined) {
       throw 'setActive: could not find wallet';
     }
+    wallet.address = utils.toChecksumAddress(wallet.address);
     setState({ ...state, wallet: wallet, wallets: state.wallets });
   };
 

--- a/src/services/AkromaApi.ts
+++ b/src/services/AkromaApi.ts
@@ -7,6 +7,7 @@ export const getTransactionsByAddress = async (address: string, page: number) =>
     return json;
   } catch (error) {
     console.log(error);
+    return [];
   }
 };
 
@@ -17,5 +18,6 @@ export const getBlockByNumber = async (blockNumber: string) => {
     return json;
   } catch (error) {
     console.log(error);
+    return [];
   }
 };


### PR DESCRIPTION
[Issue-89](https://github.com/akroma-project/akroma-wallet-mobile/issues/89)

## Description
At the moment of creating a wallet through the app, it's not showing the history information. But when we import that wallet as a "watch" it shows the information. This is a functionality error it should show all the information without needing to "watch" the wallet.

## Cause
The wallets created at the app are in lower case.
#### Example
A address created on the app is: ``0xcc973303a7af987801e266a037c3f5471c5f73d1``
but the correct format to consult is: ``0xcc973303a7aF987801E266a037c3f5471C5f73D1 ``

- Using the first one to consult de api of transactions return an empty array.
- And using the second one the consult will return the correct data.

## Solution
Implement the function toChecksumAddress from typesafe-web3 to send the correct formate.

closes #89 