### PR TITLE
style: remove send & receive buttons inside a watch wallet 

### DIFF
--- a/src/screens/wallets/WalletDetailsScreen.tsx
+++ b/src/screens/wallets/WalletDetailsScreen.tsx
@@ -69,7 +69,7 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
       </Text>
     </View>
   );
-
+  const isWatchWallet = state.wallet.encrypted === 'watch';
   return (
     <SafeAreaView style={GlobalStyles.flex}>
       <ScrollView style={GlobalStyles.container} contentContainerStyle={GlobalStyles.container} refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
@@ -79,9 +79,11 @@ export const WalletDetailsScreen = ({ route }: { route: any }) => {
             <Text>{state.wallet.address}</Text>
           </TouchableOpacity>
         </Card>
-        <View style={GlobalStyles.actions}>
-          <WalletActionButtons />
-        </View>
+        {!isWatchWallet && (
+          <View style={GlobalStyles.actions}>
+            <WalletActionButtons />
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
[Issue-93](https://github.com/akroma-project/akroma-wallet-mobile/issues/93)

## Description
In an own wallet there is a send & receive buttons, these same buttons are reflected in the watch wallets. But a user can't have control over a watch wallet. These buttons should be removed from this section.

## Expected
On details wallets screen of 'watch wallet' would not display the buttons: Receive and Send

closes #93 