### PR TITLE
feat: Import a Wallet info through a Key Store

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-native": "0.70.6",
     "react-native-camera": "^4.2.1",
     "react-native-cloud-store": "^0.9.1",
+    "react-native-document-picker": "^8.1.3",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-get-random-values": "^1.8.0",

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -25,7 +25,9 @@ const GlobalStyles = StyleSheet.create({
   body: {
     flex: 1,
   },
-  button: {},
+  button: {
+    marginBottom: 20,
+  },
   colorWhite: {
     color: 'white',
   },

--- a/src/screens/home/ImportWalletKeystore.tsx
+++ b/src/screens/home/ImportWalletKeystore.tsx
@@ -1,20 +1,39 @@
 import * as React from 'react';
-import { ActivityIndicator, SafeAreaView, View } from 'react-native';
+import { ActivityIndicator, Platform, SafeAreaView, View } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { useState } from 'react';
 import { Button, Input } from '@ui-kitten/components';
 import { useDatabaseConnection } from '../../data/connection';
 import { AkromaRn } from '@akroma-project/akroma-react-native';
 import { ImageOverlay } from '../../extra/image-overlay.component';
+import DocumentPicker, { isInProgress } from 'react-native-document-picker';
+import RNFS from 'react-native-fs';
+import { PermissionsAndroid } from 'react-native';
+import { checkPermission } from '../../utils/Permissions';
+import { WalletContext } from '../../providers/WalletProvider';
+import Toast from 'react-native-toast-message';
+
 const akromaRn = new AkromaRn();
+const permissionsRequiered = [PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE, PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE];
 
 export const ImportWalletKeystore = () => {
+  const { addWallet, refreshWallets, loadWallets } = React.useContext(WalletContext);
+
   const { walletsRepository } = useDatabaseConnection();
   const [walletJson, walletJsonChange] = useState('');
   const [walletPassword, walletPasswordChange] = useState('');
   const [name, setName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
-
+  React.useEffect(() => {
+    if (Platform.OS === 'android') {
+      (async () => await checkPermission(permissionsRequiered))();
+    }
+  }, []);
+  const cleanInputs = () => {
+    walletJsonChange('');
+    walletPasswordChange('');
+    setName('');
+  };
   const OnImportPress = async () => {
     setLoading(true);
     try {
@@ -22,15 +41,28 @@ export const ImportWalletKeystore = () => {
         const valid: Boolean = await akromaRn.validateKeystoreCreds(walletJson, walletPassword);
         if (valid) {
           const wallet = await akromaRn.loadWallet(walletJson, walletPassword);
-          await walletsRepository.create({
+          const created = await walletsRepository.create({
             name: name,
             address: wallet.address,
             pin: walletPassword,
             encrypted: walletJson,
           });
+          addWallet(created);
+          await refreshWallets();
+          await loadWallets();
           console.debug(`wallet opened:: ${wallet}`);
+          cleanInputs();
+          Toast.show({
+            type: 'success',
+            text1: 'Imported wallet.',
+            position: 'top',
+          });
         } else {
-          console.debug('unable to load wallet');
+          Toast.show({
+            type: 'error',
+            text1: 'unable to load wallet',
+            position: 'top',
+          });
         }
       }, 600);
     } catch (error) {
@@ -53,7 +85,30 @@ export const ImportWalletKeystore = () => {
     }
     return false;
   };
-
+  const handleError = (err: unknown) => {
+    if (DocumentPicker.isCancel(err)) {
+      console.warn('cancelled');
+      // User cancelled the picker, exit any dialogs or menus and move on
+    } else if (isInProgress(err)) {
+      console.warn('multiple pickers were opened, only the last will be considered');
+    } else {
+      throw err;
+    }
+  };
+  const loadJson = async () => {
+    try {
+      const pickerResult = await DocumentPicker.pickSingle({
+        presentationStyle: 'fullScreen',
+        copyTo: 'cachesDirectory',
+        // type: DocumentPicker.types.plainText,
+      });
+      pickerResult.uri;
+      const res = await RNFS.readFile(pickerResult.fileCopyUri);
+      walletJsonChange(res);
+    } catch (e) {
+      handleError(e);
+    }
+  };
   return (
     <SafeAreaView style={GlobalStyles.flex}>
       <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
@@ -64,10 +119,23 @@ export const ImportWalletKeystore = () => {
             <View>
               <Input style={GlobalStyles.input} onChangeText={setName} value={name} placeholder="Wallet name, min 5 chars" disabled={loading} />
               <Input style={GlobalStyles.input} onChangeText={walletPasswordChange} value={walletPassword} placeholder="Current Wallet Password" disabled={loading} />
-              <Input style={GlobalStyles.input} onChangeText={walletJsonChange} value={walletJson} numberOfLines={8} placeholder="Wallet JSON" disabled={loading} />
-              <Button disabled={loading || invalid()} onPress={async () => await OnImportPress()}>
-                IMPORT
-              </Button>
+
+              <Input multiline={true} style={GlobalStyles.button} value={walletJson} numberOfLines={14} placeholder="Wallet JSON" disabled={true} />
+
+              {loading ? (
+                <ActivityIndicator size="large" />
+              ) : (
+                <View>
+                  <View style={GlobalStyles.input}>
+                    <Button style={GlobalStyles.input} onPress={async () => await loadJson()}>
+                      Load JSON
+                    </Button>
+                  </View>
+                  <Button disabled={loading || invalid()} onPress={async () => await OnImportPress()}>
+                    IMPORT
+                  </Button>
+                </View>
+              )}
             </View>
           </View>
         )}

--- a/src/utils/Permissions.ts
+++ b/src/utils/Permissions.ts
@@ -1,0 +1,27 @@
+import { PermissionsAndroid, Permission } from 'react-native';
+const requestPermission = async (permissions: Permission[]) => {
+  try {
+    const granted = await PermissionsAndroid.requestMultiple(permissions);
+    if (granted) {
+      console.log('permission gratend');
+    } else {
+      console.log('permission denied');
+    }
+  } catch (err) {
+    console.warn(err);
+  }
+};
+export const checkPermission = async (permissions: Permission[]) => {
+  console.log(permissions);
+  const permissionsDenied: Permission[] = [];
+  for (let i = 0; i < permissions.length; i++) {
+    const grated = await PermissionsAndroid.check(permissions[i]);
+    if (!grated) {
+      console.log('Permission denied: ', permissions[i]);
+      permissionsDenied.push(permissions[i]);
+    }
+  }
+  if (permissionsDenied.length > 0) {
+    await requestPermission(permissionsDenied);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7495,6 +7495,13 @@ react-native-codegen@^0.70.6:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
+react-native-document-picker@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-8.1.3.tgz#200b47c182d2d654747b5e41b5843fd378ac9d2e"
+  integrity sha512-lC+SZnzqIEE30x2CSHeZT+f7FzhQOTJprCNMRPpFVl4mLV9dDCJ/wZAmMByJFT79oQMPrzjlhhJlmjm+sVRUWQ==
+  dependencies:
+    invariant "^2.2.4"
+
 react-native-eva-icons@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-eva-icons/-/react-native-eva-icons-1.3.1.tgz#1e6e019b0fd3cb1669db50bd6bbdaa6d89327593"


### PR DESCRIPTION
[Issue-115](https://github.com/akroma-project/akroma-wallet-mobile/issues/115)
A user must be able to pull out all the information of his wallet through a Key Store. We should add this functionality, so once the user inserts his key store, he can see the information previously stored in his wallet.

## How to test
1. Go to Home Screen
2. Open options.
3. Select import Keystore.
4. add name
5. add pin, should be the correct pin of the Keystore not new one.
6. import JSON, from storage
7. Press import.

## Additional Comments
you can import the next one to test it
[wallet copy.txt](https://github.com/akroma-project/akroma-wallet-mobile/files/10428623/wallet.copy.txt)


## Closes
closes #115 
- #someissue
