### PR TITLE
fix: decimal numbers on wallets

### DIFF
--- a/src/data/entities/wallet.ts
+++ b/src/data/entities/wallet.ts
@@ -11,7 +11,7 @@ export class WalletModel {
   @Column({ name: 'address', type: 'varchar', nullable: false })
   address: string;
 
-  @Column({ name: 'lastBalance', type: 'int', nullable: true, default: 0 })
+  @Column({ name: 'lastBalance', type: 'float', nullable: true, default: 0 })
   lastBalance?: Number;
 
   // @Column({ name: 'name', type: 'varchar', nullable: false })

--- a/src/extra/numberFormat.ts
+++ b/src/extra/numberFormat.ts
@@ -1,5 +1,10 @@
+const localStringOptions = {
+  maximumFractionDigits: 12,
+  minimumFractionDigits: 2,
+};
+
 const formatNumber: (value: number) => string = (value: number) => {
-  return new Intl.NumberFormat('en-US').format(value);
+  return value?.toLocaleString('en-US', localStringOptions);
 };
 
 export default formatNumber;

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -81,7 +81,7 @@ const WalletProvider = (props: serverProviderProps) => {
     const success = await provider.getBalance(wallet.address);
     let balance = 0;
     if (success.ok) {
-      balance = parseInt(utils.fromWei(success.data ?? 0, 'ether').toString(), 10);
+      balance = parseFloat(utils.fromWei(success.data ?? 0, 'ether').toString());
     }
 
     const updated: WalletModel = {


### PR DESCRIPTION
Changed type of wallet last balance to float, so not to lose any details