### PR TITLE
feat: create the transaction screen with the new design 

### DIFF
--- a/ios/AkromaWallet/Info.plist
+++ b/ios/AkromaWallet/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -20,12 +22,12 @@
 	<string>507652349383-rmhtbabce3ir7tk5pmv32j9qug0bfc9o.apps.googleusercontent.com</string>
 	<key>CFBundleURLTypes</key>
 	<array>
-	<dict>
-		<key>CFBundleURLSchemes</key>
-		<array>
-		<string>com.googleusercontent.apps.507652349383-rmhtbabce3ir7tk5pmv32j9qug0bfc9o</string>
-		</array>
-	</dict>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.507652349383-rmhtbabce3ir7tk5pmv32j9qug0bfc9o</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
@@ -50,7 +52,7 @@
 	<string>for any reason</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>for any reason</string>
-  <key>NSCameraUsageDescription</key>
+	<key>NSCameraUsageDescription</key>
 	<string>To scan the QR of the wallets</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>for any reason</string>
@@ -69,17 +71,16 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSUbiquitousContainers</key>
-    <dict>
-        <key>iCloud.org.reactjs.native.example.AkromaWallet</key>
-        <dict>
-            <key>NSUbiquitousContainerIsDocumentScopePublic</key>
-            <true/>
-            <key>NSUbiquitousContainerName</key>
-            <string>AkromaWallet</string>
+	<dict>
+		<key>iCloud.org.reactjs.native.example.AkromaWallet</key>
+		<dict>
+			<key>NSUbiquitousContainerIsDocumentScopePublic</key>
+			<true/>
+			<key>NSUbiquitousContainerName</key>
+			<string>AkromaWallet</string>
 			<key>NSUbiquitousContainerSupportedFolderLevels</key>
 			<string>Any</string>
-        </dict>
-    </dict>
+		</dict>
+	</dict>
 </dict>
-
 </plist>

--- a/src/assets/svg/ArrowleftSvg.tsx
+++ b/src/assets/svg/ArrowleftSvg.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+function ArrowleftSvg(props: any) {
+  return (
+    <Svg width={18} height={15} viewBox="0 0 18 15" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <Path
+        d="M0 7.5c0 .242.107.465.3.65l6.437 6.426c.194.184.397.271.63.271.475 0 .853-.348.853-.833a.849.849 0 00-.243-.61l-2.17-2.21-3.84-3.5-.203.475 3.121.194h12.262c.504 0 .853-.359.853-.863s-.349-.863-.853-.863H4.885l-3.12.194.203.485 3.838-3.509 2.171-2.21a.865.865 0 00.243-.61c0-.485-.378-.834-.853-.834-.233 0-.436.077-.65.29L.3 6.852a.889.889 0 00-.3.65z"
+        fill="#1C1C1E"
+      />
+    </Svg>
+  );
+}
+
+export default ArrowleftSvg;

--- a/src/assets/svg/MinusSvg.tsx
+++ b/src/assets/svg/MinusSvg.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Svg, { Rect } from 'react-native-svg';
+
+function MinusSvg(props: any) {
+  return (
+    <Svg width={37} height={5} viewBox="0 0 37 5" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <Rect x={0.5} width={36} height={5} rx={2.5} fill="#B9B9B9" />
+    </Svg>
+  );
+}
+
+export default MinusSvg;

--- a/src/assets/svg/TopMenuSvg.tsx
+++ b/src/assets/svg/TopMenuSvg.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import Svg, { Rect } from 'react-native-svg';
+
+function TopMenuSvg(props: any) {
+  return (
+    <Svg width={37} height={5} viewBox="0 0 37 5" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <Rect x={0.5} width={36} height={5} rx={2.5} fill="#B9B9B9" />
+    </Svg>
+  );
+}
+
+export default TopMenuSvg;

--- a/src/components/HomeResumeAmount.tsx
+++ b/src/components/HomeResumeAmount.tsx
@@ -16,8 +16,9 @@ export const HomeResumeAmount = (params: Params) => {
 
   return (
     <View style={styles.resumeContainer}>
+      <AkaIcon style={styles.icon} />
+
       <LinearGradient style={styles.resumeCard} colors={['#8F0000', '#DB0000']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }} locations={[0.0588, 0.9449]}>
-        <AkaIcon style={styles.icon} />
         <View>
           <Text style={styles.title}>AKA Balance</Text>
           <Text style={styles.textAmount}>{params.balance?.toLocaleString('en-US', localStringOptions)}</Text>
@@ -33,7 +34,8 @@ const styles = StyleSheet.create({
     height: 30,
     width: 32,
     position: 'absolute',
-    top: -15,
+    top: 15,
+    zIndex: 99,
   },
   resumeContainer: {
     alignItems: 'center',

--- a/src/components/HomeTransferButtons.tsx
+++ b/src/components/HomeTransferButtons.tsx
@@ -6,7 +6,7 @@ import ArrowupSvg from '../assets/svg/ArrowupSvg';
 import GlobalStyles from '../constants/GlobalStyles';
 export const HomeTransferButtons = () => {
   return (
-    <View style={GlobalStyles.transferButtonsContainer}>
+    <View style={[GlobalStyles.transferButtonsContainer]}>
       <Button accessoryLeft={() => <ArrowupSvg />} style={GlobalStyles.transferButton} status="control">
         {() => <Text style={GlobalStyles.textButton}>Send</Text>}
       </Button>

--- a/src/components/HomeTransferButtons.tsx
+++ b/src/components/HomeTransferButtons.tsx
@@ -7,21 +7,11 @@ import GlobalStyles from '../constants/GlobalStyles';
 export const HomeTransferButtons = () => {
   return (
     <View style={GlobalStyles.transferButtonsContainer}>
-      <Button style={GlobalStyles.transferButton} status="control">
-        {() => (
-          <View style={GlobalStyles.buttonIconContent}>
-            <ArrowupSvg />
-            <Text style={GlobalStyles.textButton}>Send</Text>
-          </View>
-        )}
+      <Button accessoryLeft={() => <ArrowupSvg />} style={GlobalStyles.transferButton} status="control">
+        {() => <Text style={GlobalStyles.textButton}>Send</Text>}
       </Button>
-      <Button style={GlobalStyles.transferButton} status="control">
-        {() => (
-          <View style={GlobalStyles.buttonIconContent}>
-            <ArrowdownSvg />
-            <Text style={GlobalStyles.textButton}>Receive</Text>
-          </View>
-        )}
+      <Button accessoryLeft={() => <ArrowdownSvg />} style={GlobalStyles.transferButton} status="control">
+        {() => <Text style={GlobalStyles.textButton}>Receive</Text>}
       </Button>
     </View>
   );

--- a/src/components/TopWallets.tsx
+++ b/src/components/TopWallets.tsx
@@ -5,6 +5,10 @@ import { WalletModel } from '../data/entities/wallet';
 import { StyleSheet, Text, View, TouchableHighlight, ScrollView } from 'react-native';
 import { WalletCard } from './WalletCard';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { WalletContext } from '../providers/WalletProvider';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { HomeStackParamList } from '../navigation/HomeStackNavigator';
+import { useNavigation } from '@react-navigation/core';
 interface Props {
   wallets: WalletModel[];
 }
@@ -13,19 +17,28 @@ interface WalletsSectionParams {
   wallets: WalletModel[];
   style?: any;
 }
-const WalletsSection = (params: WalletsSectionParams) => (
-  <View style={params.style}>
-    <Text style={styles.subTitle}>{params.title}</Text>
-    {params.wallets?.map(wallet => (
-      <TouchableHighlight underlayColor="#DDDDDD" key={wallet.id} onPress={() => console.log(wallet.address)}>
-        <View>
-          <WalletCard wallet={wallet} />
-          <Divider />
-        </View>
-      </TouchableHighlight>
-    ))}
-  </View>
-);
+const WalletsSection = (params: WalletsSectionParams) => {
+  const { setActive } = React.useContext(WalletContext);
+  type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
+  const navigator = useNavigation<homeScreenProp>();
+  const handleSelect = (id: string) => {
+    setActive(id);
+    navigator.navigate('TransactionScreen');
+  };
+  return (
+    <View style={params.style}>
+      <Text style={styles.subTitle}>{params.title}</Text>
+      {params.wallets?.map(wallet => (
+        <TouchableHighlight underlayColor="#DDDDDD" key={wallet.id} onPress={() => handleSelect(wallet.id)}>
+          <View>
+            <WalletCard wallet={wallet} />
+            <Divider />
+          </View>
+        </TouchableHighlight>
+      ))}
+    </View>
+  );
+};
 export const TopWallets = ({ wallets }: Props) => {
   const [walletsState, setWalletsState] = useState<WalletModel[]>();
   const [watchWallets, setWatchWallets] = useState<WalletModel[]>();
@@ -40,7 +53,7 @@ export const TopWallets = ({ wallets }: Props) => {
   }, [wallets]);
   return (
     <View style={[GlobalStyles.walletsContainer]}>
-      <Text style={styles.title}>Wallets</Text>
+      <Text style={[GlobalStyles.titleText, GlobalStyles.pv24]}>Wallets</Text>
       <SafeAreaView>
         <ScrollView>
           <WalletsSection title={'My Wallets'} wallets={walletsState} />
@@ -54,14 +67,6 @@ export const TopWallets = ({ wallets }: Props) => {
 const styles = StyleSheet.create({
   walletsSection: {
     paddingTop: 30,
-  },
-  title: {
-    fontSize: 18,
-    paddingHorizontal: 20,
-    paddingVertical: 24,
-    fontWeight: '600',
-    textAlign: 'center',
-    color: '#1C1C1E',
   },
   subTitle: {
     paddingHorizontal: 20,

--- a/src/components/TopWallets.tsx
+++ b/src/components/TopWallets.tsx
@@ -18,10 +18,11 @@ interface WalletsSectionParams {
   style?: any;
 }
 const WalletsSection = (params: WalletsSectionParams) => {
-  const { setActive } = React.useContext(WalletContext);
+  const { setActive, updateBalance } = React.useContext(WalletContext);
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
   const navigator = useNavigation<homeScreenProp>();
   const handleSelect = (id: string) => {
+    updateBalance(id);
     setActive(id);
     navigator.navigate('TransactionScreen');
   };

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import { Text, Avatar, Layout, Card } from '@ui-kitten/components';
+import { StyleSheet, TouchableWithoutFeedback, View } from 'react-native';
+import { Text, Card } from '@ui-kitten/components';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { useNavigation } from '@react-navigation/native';
 import { WalletsStackParamList } from '../navigation/WalletsStackNavigator';
+import GlobalStyles from '../constants/GlobalStyles';
+import { getAddressFormat } from '../utils/Wallet';
 interface Props {
   addressFrom: string;
   addressTo: string;
@@ -12,18 +14,9 @@ interface Props {
   blockNumber?: string;
   sent?: boolean;
 }
-const bannerColor = (status: string) => {
-  if (status === 'In Progress') {
-    return 'blue';
-  } else if (status === 'Successful') {
-    return 'green';
-  } else {
-    return 'red';
-  }
-};
 
 export const TransactionCard = (props: Props) => {
-  const { addressFrom, addressTo, status, amount, blockNumber, sent } = props;
+  const { addressFrom, addressTo, amount, blockNumber, sent } = props;
   type walletScreenProp = StackNavigationProp<WalletsStackParamList, 'BlockNumber'>;
   const navigator = useNavigation<walletScreenProp>();
   const goDetailts = (block: string) => {
@@ -33,56 +26,28 @@ export const TransactionCard = (props: Props) => {
       });
     }
   };
+  const sentReceivedLabel = sent ? 'Sent' : 'Received';
+  const address = sent ? addressTo : addressFrom;
   return (
-    <View>
-      <Layout style={bannerStyle(bannerColor(status)).bannerContainer}>
-        <Text style={styles.banner}>{status}</Text>
-      </Layout>
-      <Card onPress={() => goDetailts(blockNumber)} style={styles.card}>
-        <Layout style={styles.container} level="1">
-          <Layout style={styles.avatarContainer}>
-            <Avatar source={require('../assets/images/icon.png')} />
-          </Layout>
-
-          <Layout style={styles.bodyContainer}>
-            <Text style={styles.textAddress}>
-              <Text style={styles.textBold}>From: </Text>
-              {addressFrom}
+    <Card style={styles.card}>
+      <TouchableWithoutFeedback onPress={() => goDetailts(blockNumber)}>
+        <View style={[GlobalStyles.flexRowBetween]}>
+          <View>
+            <Text style={[GlobalStyles.generalText, GlobalStyles.textBold]}>{sentReceivedLabel}</Text>
+            <Text style={[GlobalStyles.smallText]}>{getAddressFormat(address)}</Text>
+          </View>
+          <View>
+            <Text style={[GlobalStyles.generalText, GlobalStyles.textBold, !sent && GlobalStyles.greenColor]}>
+              {sent ? '-' : '+'} {amount}
             </Text>
-            <Text style={styles.textAddress}>
-              <Text style={styles.textBold}>To: </Text>
-              {addressTo}
-            </Text>
-            {blockNumber && (
-              <Text style={styles.textAddress}>
-                <Text style={styles.textBold}>#Block: </Text>
-                {blockNumber}
-              </Text>
-            )}
-            <Text style={[sent ? styles.sent : styles.received, styles.textBold]}>
-              {sent ? '-' : '+'} {amount} AKA
-            </Text>
-          </Layout>
-        </Layout>
-      </Card>
-    </View>
+            <Text style={GlobalStyles.textRight}>Fecha</Text>
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+    </Card>
   );
 };
 
-const bannerStyle = (color: string) =>
-  StyleSheet.create({
-    bannerContainer: {
-      top: -10,
-      right: 15,
-      position: 'absolute',
-      zIndex: 2,
-      alignItems: 'baseline',
-      alignSelf: 'flex-end',
-      backgroundColor: color,
-      borderRadius: 4,
-      marginBottom: 8,
-    },
-  });
 const styles = StyleSheet.create({
   sent: {
     color: 'red',
@@ -119,6 +84,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
   },
   card: {
-    borderRadius: 20,
+    borderRadius: 0,
+    borderWidth: 0,
+    paddingHorizontal: 0,
+    justifyContent: 'center',
+    height: 72,
   },
 });

--- a/src/components/TransactionSection.tsx
+++ b/src/components/TransactionSection.tsx
@@ -1,24 +1,71 @@
 import GlobalStyles from '../constants/GlobalStyles';
-import React from 'react';
-import { StyleSheet, Text, View, ScrollView } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import React, { useEffect, useRef, useState } from 'react';
+import { StyleSheet, Text, View, ScrollView, Dimensions, SafeAreaView, FlatList } from 'react-native';
 
 import { TransactionSectionTop } from './TransactionSectionTop';
+import { getTransactionsByAddress } from '../services/AkromaApi';
+import { TransactionCard } from './TransactionCard';
+import { Utils } from 'typesafe-web3/dist/lib/utils';
+import { WalletContext } from '../providers/WalletProvider';
+import { Divider } from '@ui-kitten/components';
+const screenHeight = Dimensions.get('window').height;
 
-export const TransactionSection = () => {
+export const TransactionSection = ({ setDisplayButtons }) => {
+  const { getTransactionCountByAddress, state } = React.useContext(WalletContext);
+
+  const [transactions, setTransactions] = useState([]);
+  const [page, setPage] = useState(1);
+  const listRef = useRef(null);
+  // const handlePage = (newValue: number) => {
+  //   listRef.current.scrollTo({ y: 0, animated: true });
+  //   setPage(newValue);
+  // };
+  const utils = new Utils();
+  const sumAddress = utils.toChecksumAddress(state.wallet.address);
+
+  useEffect(() => {
+    getTransactionsByAddress(sumAddress, page - 1).then(json => {
+      setTransactions(transactions.concat(json));
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page]);
+  const loadMoreTransactions = () => {
+    setPage(page + 1);
+  };
+  const onViewableItemsChanged = ({ viewableItems, changed }) => {
+    console.log('Visible items are', viewableItems);
+    console.log('Changed in this iteration', changed);
+  };
   return (
-    <View style={[GlobalStyles.walletsContainer]}>
+    <SafeAreaView style={[GlobalStyles.walletsContainer]}>
       <TransactionSectionTop />
-      <SafeAreaView>
-        <ScrollView>
-          <Text>Transactions list</Text>
-        </ScrollView>
-      </SafeAreaView>
-    </View>
+      <FlatList
+        ref={listRef}
+        keyExtractor={({ id }) => id}
+        data={transactions}
+        renderItem={({ item }) => <TransactionCard addressFrom={item.from} amount={String(item.value * 0.000000000000000001)} addressTo={item.to} sent={item.from === sumAddress} />}
+        onEndReached={loadMoreTransactions}
+        ItemSeparatorComponent={() => <Divider />}
+        onScrollBeginDrag={() => console.log('start')}
+        nestedScrollEnabled={true}
+        onScroll={event => {
+          let currentOffset = event.nativeEvent.contentOffset.y;
+          if (currentOffset > 200) {
+            setDisplayButtons('none');
+          } else {
+            setDisplayButtons('flex');
+          }
+        }}
+      />
+    </SafeAreaView>
   );
 };
 
 const styles = StyleSheet.create({
+  walletsList: {
+    maxHeight: screenHeight - 206,
+    minHeight: screenHeight - 206,
+  },
   walletsSection: {
     paddingTop: 30,
     textAlign: 'center',

--- a/src/components/TransactionSection.tsx
+++ b/src/components/TransactionSection.tsx
@@ -1,0 +1,36 @@
+import GlobalStyles from '../constants/GlobalStyles';
+import React from 'react';
+import { StyleSheet, Text, View, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { TransactionSectionTop } from './TransactionSectionTop';
+
+export const TransactionSection = () => {
+  return (
+    <View style={[GlobalStyles.walletsContainer]}>
+      <TransactionSectionTop />
+      <SafeAreaView>
+        <ScrollView>
+          <Text>Transactions list</Text>
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  walletsSection: {
+    paddingTop: 30,
+    textAlign: 'center',
+  },
+  subTitle: {
+    paddingHorizontal: 20,
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1C1C1E',
+  },
+  container: {
+    height: '29%',
+    backgroundColor: 'red',
+  },
+});

--- a/src/components/TransactionSectionTop.tsx
+++ b/src/components/TransactionSectionTop.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Button } from '@ui-kitten/components';
+import GlobalStyles from '../constants/GlobalStyles';
+import { Text, View } from 'react-native';
+import ArrowleftSvg from '../assets/svg/ArrowleftSvg';
+import MinusSvg from '../assets/svg/MinusSvg';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { HomeStackParamList } from '../navigation/HomeStackNavigator';
+import { useNavigation } from '@react-navigation/core';
+import { WalletContext } from '../providers/WalletProvider';
+
+export const TransactionSectionTop = () => {
+  const { cleanWalletActive } = React.useContext(WalletContext);
+  type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
+  const navigator = useNavigation<homeScreenProp>();
+  const handleBack = () => {
+    cleanWalletActive();
+    navigator.navigate('HomeScreen');
+  };
+  return (
+    <View style={GlobalStyles.pt8}>
+      <View style={GlobalStyles.alingItemsCenter}>
+        <MinusSvg />
+      </View>
+      <View style={[GlobalStyles.flexRow, GlobalStyles.displayFlex]}>
+        <View style={[GlobalStyles.flex, GlobalStyles.alingItemsStart]}>
+          <Button onPress={handleBack} appearance="ghost" accessoryLeft={<ArrowleftSvg />} />
+        </View>
+        <View style={GlobalStyles.flex}>
+          <Text style={[GlobalStyles.titleText, GlobalStyles.pt10]}>Transactions</Text>
+        </View>
+        <View style={GlobalStyles.flex} />
+      </View>
+    </View>
+  );
+};

--- a/src/components/WalletCard.tsx
+++ b/src/components/WalletCard.tsx
@@ -10,7 +10,7 @@ interface Params {
 export const WalletCard = (params: Params) => {
   console.log(params);
   return (
-    <View style={[GlobalStyles.walletCard, GlobalStyles.flexRowBetween]}>
+    <View style={[GlobalStyles.walletCard, GlobalStyles.flexRowBetween, GlobalStyles.ph24]}>
       <View>
         <Text style={[GlobalStyles.generalText, GlobalStyles.textBold]}>{params.wallet.name}</Text>
         <Text style={[GlobalStyles.smallText]}>{getAddressFormat(params.wallet.address)}</Text>

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -238,7 +238,7 @@ const GlobalStyles = StyleSheet.create({
   },
   walletCard: {
     minHeight: 70,
-    paddingHorizontal: 24,
+    maxHeight: 70,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -263,6 +263,15 @@ const GlobalStyles = StyleSheet.create({
   },
   alingItemsStart: {
     alignItems: 'flex-start',
+  },
+  greenColor: {
+    color: '#0F8400',
+  },
+  textRight: {
+    textAlign: 'right',
+  },
+  ph24: {
+    paddingHorizontal: 24,
   },
 });
 

--- a/src/constants/GlobalStyles.ts
+++ b/src/constants/GlobalStyles.ts
@@ -148,10 +148,10 @@ const GlobalStyles = StyleSheet.create({
   },
 
   titleText: {
-    fontSize: 20,
-    fontWeight: 'bold',
+    fontSize: 18,
+    fontWeight: '600',
     textAlign: 'center',
-    color: '#fba304',
+    color: '#1C1C1E',
   },
   headerContainer: {
     display: 'flex',
@@ -216,14 +216,6 @@ const GlobalStyles = StyleSheet.create({
     fontSize: 16,
     paddingLeft: 10,
   },
-  buttonIconContent: {
-    display: 'flex',
-    flexDirection: 'row',
-    padding: 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-  },
   walletsContainer: {
     display: 'flex',
     borderTopLeftRadius: 24,
@@ -249,6 +241,28 @@ const GlobalStyles = StyleSheet.create({
     paddingHorizontal: 24,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  backArrow: {
+    top: 10,
+    left: 24,
+  },
+  alingItemsCenter: {
+    alignItems: 'center',
+  },
+  pt8: {
+    paddingTop: 8,
+  },
+  pt10: {
+    paddingTop: 10,
+  },
+  pv24: {
+    paddingVertical: 24,
+  },
+  displayFlex: {
+    display: 'flex',
+  },
+  alingItemsStart: {
+    alignItems: 'flex-start',
   },
 });
 

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,0 +1,23 @@
+import React, { useContext } from 'react';
+import { SafeAreaView } from 'react-native';
+import GlobalStyles from '../constants/GlobalStyles';
+
+import { HomeHeader } from '../components/HomeHeader';
+import { HomeResumeAmount } from '../components/HomeResumeAmount';
+import { WalletContext } from '../providers/WalletProvider';
+
+const MainLayout = ({ children }) => {
+  const { state } = useContext(WalletContext);
+  const resumeBalance = state.wallet.address ? state.wallet.lastBalance : state.totalBalance;
+
+  return (
+    <SafeAreaView style={[GlobalStyles.generalBackground, GlobalStyles.flex]}>
+      <HomeHeader address={state.wallet.address || ''} name={state.wallet.name || ''} />
+      <HomeResumeAmount balance={resumeBalance} />
+      {children}
+      {/* <LastTransactions wallets={state.wallets} /> */}
+    </SafeAreaView>
+  );
+};
+
+export default MainLayout;

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -12,9 +12,11 @@ import { ImportWalletSeedPhrase } from '../screens/home/ImportWalletSeedPhrase';
 import { ImportWalletWatch } from '../screens/home/ImportWalletWatch';
 import { WalletSettingsHeaderRight } from '../components/WalletSettingsHeaderRight';
 import { WalletModel } from '../data/entities/wallet';
+import { TransactionScreen } from '../screens/home/TransactionScreen';
 
 export type HomeStackParamList = {
   HomeScreen: { update: boolean } | undefined;
+  TransactionScreen: undefined;
   SendCoinScreen: { address: string } | undefined;
   ScannerScreen: undefined;
   ReceiveCoinScreen: undefined;
@@ -35,6 +37,8 @@ export function HomeStackNavigator() {
         headerShown: true,
       })}>
       <HomeStack.Screen name="HomeScreen" component={HomeScreen} options={{ headerShown: false }} />
+      <HomeStack.Screen name="TransactionScreen" component={TransactionScreen} options={{ headerShown: false }} />
+
       <HomeStack.Screen name="CreateWalletScreen" component={CreateWalletScreen} options={{ title: 'Create' }} />
       <HomeStack.Screen name="SendCoinScreen" component={SendCoinScreen} options={{ title: 'Send' }} />
       <HomeStack.Screen name="ScannerScreen" component={ScannerScreen} options={{ title: 'Scan' }} />

--- a/src/navigation/HomeStackNavigator.tsx
+++ b/src/navigation/HomeStackNavigator.tsx
@@ -35,6 +35,8 @@ export function HomeStackNavigator() {
     <HomeStack.Navigator
       screenOptions={() => ({
         headerShown: true,
+        gestureDirection: 'horizontal',
+        gestureEnabled: true,
       })}>
       <HomeStack.Screen name="HomeScreen" component={HomeScreen} options={{ headerShown: false }} />
       <HomeStack.Screen name="TransactionScreen" component={TransactionScreen} options={{ headerShown: false }} />

--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -14,6 +14,7 @@ type Props = {
   updateBalance: (id: string) => Promise<WalletModel>;
   setWallets: (wallets: WalletModel[]) => void;
   setActive: (id: string) => void;
+  cleanWalletActive: () => void;
   send: (to: string, value: string) => Promise<string>;
   getTransactionCountByAddress: (address: string) => Promise<number>;
   refreshWallets: () => Promise<void>;
@@ -69,7 +70,10 @@ const WalletProvider = (props: serverProviderProps) => {
     }
     setState({ ...state, wallet: wallet, wallets: state.wallets });
   };
-
+  const cleanWalletActive = (): void => {
+    const cleanWallet = new WalletModel();
+    setState({ ...state, wallet: cleanWallet, wallets: state.wallets });
+  };
   const updateBalance = async (id: string): Promise<WalletModel> => {
     console.debug('update balance called', id);
     const wallet = state.wallets.find(x => x.id === id);
@@ -150,6 +154,7 @@ const WalletProvider = (props: serverProviderProps) => {
     send: send,
     getTransactionCountByAddress: getTransactionCountByAddress,
     refreshWallets,
+    cleanWalletActive: cleanWalletActive,
   };
 
   return <WalletContext.Provider value={initalValue}>{props.children}</WalletContext.Provider>;

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -1,24 +1,19 @@
 import * as React from 'react';
-import { AppState, Platform, SafeAreaView } from 'react-native';
-import GlobalStyles from '../../constants/GlobalStyles';
+import { AppState, Platform } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { HomeStackParamList } from '../../navigation/HomeStackNavigator';
 import { useCallback, useEffect, useState } from 'react';
 
 import RNPermissions, { NotificationsResponse, Permission, PERMISSIONS, PermissionStatus } from 'react-native-permissions';
-import { HomeHeader } from '../../components/HomeHeader';
-import { HomeResumeAmount } from '../../components/HomeResumeAmount';
 import { WalletContext } from '../../providers/WalletProvider';
 import { TopWallets } from '../../components/TopWallets';
-import { LastTransactions } from '../../components/LastTransactions';
 import { useDatabaseConnection } from '../../data/connection';
-import { HomeTransferButtons } from '../../components/HomeTransferButtons';
+import MainLayout from '../../layout/MainLayout';
 
 export const HomeScreen = () => {
   const { isConnected } = useDatabaseConnection();
 
   type homeScreenProp = StackNavigationProp<HomeStackParamList, 'HomeScreen'>;
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [statuses, setStatuses] = useState<Partial<Record<Permission, PermissionStatus>>>({});
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -60,14 +55,9 @@ export const HomeScreen = () => {
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected]);
-  const resumeBalance = state.wallet.address ? state.wallet.lastBalance : state.totalBalance;
   return (
-    <SafeAreaView style={[GlobalStyles.generalBackground, GlobalStyles.flex]}>
-      <HomeHeader address={state.wallet.address || ''} name={state.wallet.name || ''} />
-      <HomeResumeAmount balance={resumeBalance} />
-      {state.wallet.address && <HomeTransferButtons />}
+    <MainLayout>
       <TopWallets wallets={state.wallets} />
-      {/* <LastTransactions wallets={state.wallets} /> */}
-    </SafeAreaView>
+    </MainLayout>
   );
 };

--- a/src/screens/home/TransactionScreen.tsx
+++ b/src/screens/home/TransactionScreen.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import { useEffect } from 'react';
+import { useState } from 'react';
+import { Animated } from 'react-native';
 import { HomeTransferButtons } from '../../components/HomeTransferButtons';
 import { TransactionSection } from '../../components/TransactionSection';
 import MainLayout from '../../layout/MainLayout';
 
 export const TransactionScreen = () => {
+  const [displayButtons, setDisplayButtons] = useState(undefined);
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+
   return (
     <MainLayout>
       <HomeTransferButtons />
-      <TransactionSection />
+
+      <TransactionSection setDisplayButtons={setDisplayButtons} />
     </MainLayout>
   );
 };

--- a/src/screens/home/TransactionScreen.tsx
+++ b/src/screens/home/TransactionScreen.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { HomeTransferButtons } from '../../components/HomeTransferButtons';
+import { TransactionSection } from '../../components/TransactionSection';
+import MainLayout from '../../layout/MainLayout';
+
+export const TransactionScreen = () => {
+  return (
+    <MainLayout>
+      <HomeTransferButtons />
+      <TransactionSection />
+    </MainLayout>
+  );
+};

--- a/src/services/AkromaApi.ts
+++ b/src/services/AkromaApi.ts
@@ -6,7 +6,7 @@ export const getTransactionsByAddress = async (address: string, page: number) =>
     const json = await res.json();
     return json;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return [];
   }
 };
@@ -17,7 +17,7 @@ export const getBlockByNumber = async (blockNumber: string) => {
     const json = await res.json();
     return json;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return [];
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,12 +2094,12 @@
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
-  version "7.1.20"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.20.tgz#e168cdd612c92a2d335029ed62ac94c95b362359"
-  integrity sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"
+  integrity sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==
   dependencies:
-    "@babel/parser" "^7.1.0"
-    "@babel/types" "^7.0.0"
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
     "@types/babel__generator" "*"
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
@@ -2150,11 +2150,6 @@
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
-
-"@types/invariant@^2.2.35":
-  version "2.2.35"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.35.tgz#cd3ebf581a6557452735688d8daba6cf0bd5a3be"
-  integrity sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -2228,9 +2223,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17", "@types/react@^18":
-  version "18.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.26.tgz#8ad59fc01fef8eaf5c74f4ea392621749f0b7917"
-  integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
+  version "18.0.27"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.27.tgz#d9425abe187a00f8a5ec182b010d4fd9da703b71"
+  integrity sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -3048,9 +3043,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001400:
-  version "1.0.30001442"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz#40337f1cf3be7c637b061e2f78582dc1daec0614"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+  version "1.0.30001445"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz#cf2d4eb93f2bcdf0310de9dd6d18be271bc0b447"
+  integrity sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3354,16 +3349,16 @@ copy-descriptor@^0.1.0:
   integrity sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==
 
 core-js-compat@^3.25.1:
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.27.1.tgz#b5695eb25c602d72b1d30cbfba3cb7e5e4cf0a67"
-  integrity sha512-Dg91JFeCDA17FKnneN7oCMz4BkQ4TcffkgHP4OWwp9yx3pi7ubqMDXXSacfNak1PQqjc95skyt+YBLHQJnkJwA==
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.27.2.tgz#607c50ad6db8fd8326af0b2883ebb987be3786da"
+  integrity sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==
   dependencies:
     browserslist "^4.21.4"
 
 core-js@^3.19.0:
-  version "3.27.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.1.tgz#23cc909b315a6bb4e418bf40a52758af2103ba46"
-  integrity sha512-GutwJLBChfGCpwwhbYoqfv03LAfmiz7e7D/BNxzeMxwQf10GRSzqiOjx7AmtEk+heiD/JWmBuyBPgFtx0Sg1ww==
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.2.tgz#85b35453a424abdcacb97474797815f4d62ebbf7"
+  integrity sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -3899,9 +3894,9 @@ eslint-plugin-react-native@^3.8.1:
     eslint-plugin-react-native-globals "^0.1.1"
 
 eslint-plugin-react@^7.20.0:
-  version "7.32.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.0.tgz#d80f794a638c5770f952ba2ae793f0a516be7c09"
-  integrity sha512-vSBi1+SrPiLZCGvxpiZIa28fMEUaMjXtCplrvxcIxGzmFiYdsXQDwInEjuv5/i/2CTTxbkS87tE8lsQ0Qxinbw==
+  version "7.32.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.1.tgz#88cdeb4065da8ca0b64e1274404f53a0f9890200"
+  integrity sha512-vOjdgyd0ZHBXNsmvU+785xY8Bfe57EFbTYYk8XrROzWpr9QBvpjITvAXt9xqcE6+8cjR/g1+mfumPToxsl1www==
   dependencies:
     array-includes "^3.1.6"
     array.prototype.flatmap "^1.3.1"
@@ -4330,9 +4325,9 @@ flatted@^3.1.0:
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
 flow-parser@0.*:
-  version "0.196.3"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.196.3.tgz#dd923f29a6c194770a4f999f8026ef1da79d428b"
-  integrity sha512-R8wj12eHW6og+IBWeRS6aihkdac1Prh4zw1bfxtt/aeu8r5OFmQEZjnmINcjO/5Q+OKvI4Eg367ygz2SHvtH+w==
+  version "0.197.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.197.0.tgz#9a581ef7c0b1c3377b195cec0bbad794b88be67b"
+  integrity sha512-yhwkJPxH1JBg0aJunk/jVRy5p3UhVZBGkzL1hq/GK+GaBh6bKr2YKkv6gDuiufaw+i3pKWQgOLtD++1cvrgXLA==
 
 flow-parser@^0.121.0:
   version "0.121.0"
@@ -6794,10 +6789,17 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.7, node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.7:
+node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.7:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.8.tgz#a68d30b162bc1d8fd71a367e81b997e1f4d4937e"
+  integrity sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -6921,9 +6923,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-inspect@^1.12.2, object-inspect@^1.9.0:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
-  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
+  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -7306,9 +7308,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.0.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.2.tgz#c4ea1b5b454d7c4b59966db2e06ed7eec5dfd160"
-  integrity sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
+  integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
 pretty-format@^26.0.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
   version "26.6.2"
@@ -7568,13 +7570,13 @@ react-native-qrcode-svg@^6.1.1:
     qrcode "^1.5.0"
 
 react-native-reanimated@^2.2.4:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.13.0.tgz#d64c1386626822d4dc22094b4efe028ff2c49cc9"
-  integrity sha512-yUHyYVIegWWIza4+nVyS3CSmI/Mc8kLFVHw2c6gnSHaYhYA4LeEjH/jBkoMzHk9Xd0Ra3cwtjYKAMG8OTp6JVg==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.2.tgz#7f20f01052ea4902e320be8725d55b40b1d21d62"
+  integrity sha512-zj05BBafk38rE78PhHc6q0vg9M4WeJY/RExHUGFiP1miJyyAaJzs2jLQR+HY0zbutCE+/yNJyOE3dca2BslsGg==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
-    "@types/invariant" "^2.2.35"
+    convert-source-map "^1.7.0"
     invariant "^2.2.4"
     lodash.isequal "^4.5.0"
     setimmediate "^1.0.5"
@@ -7586,9 +7588,9 @@ react-native-safe-area-context@3.3.2:
   integrity sha512-yOwiiPJ1rk+/nfK13eafbpW6sKW0jOnsRem2C1LPJjM3tfTof6hlvV5eWHATye3XOpu2cJ7N+HdkUvUDGwFD2Q==
 
 react-native-screens@^3.9.0:
-  version "3.18.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.2.tgz#d7ab2d145258d3db9fa630fa5379dc4474117866"
-  integrity sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.19.0.tgz#ec68685e04b074ebce4641b3a0ae7e2571629b75"
+  integrity sha512-Ehsmy7jr3H3j5pmN+/FqsAaIAD+k+xkcdePfLcg4rYRbN5X7fJPgaqhcmiCcZ0YxsU8ttsstP9IvRLNQuIkRRA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
[Issue-134](https://github.com/akroma-project/akroma-wallet-mobile/issues/134)
## Describe the solution
- when press a wallet should navigate to transaction screen
- make all the styles
- display transactions

## How to test
1. Press wallet (if don't have one, create it)

## Expected

![Screenshot 2023-01-20 at 13 54 02](https://user-images.githubusercontent.com/20717760/213794309-fad2b6c2-01a7-4906-990a-2141a8bb4430.png)


## Additional Comments
I implemented a layout to reuse the header and the balance sections because is mostly the same on home and transactions screen

## Closes
closes #134 
