### PR TITLE
fix: hide keyboard and popup on iOS

### DIFF
--- a/src/components/HomeScreenHeaderRight.tsx
+++ b/src/components/HomeScreenHeaderRight.tsx
@@ -17,8 +17,9 @@ export const HomeScreenHeaderRight = () => {
       onPress={() =>
         showActionSheetWithOptions(
           {
-            options: ['Create Wallet', 'Import Keystore', 'Import Private Key', 'Import Seed Phrase', 'Watch Wallet'],
-            cancelButtonIndex: 99,
+            options: ['Create Wallet', 'Import Keystore', 'Import Private Key', 'Import Seed Phrase', 'Watch Wallet', 'Cancel'],
+            cancelButtonIndex: 5 || 99,
+            destructiveButtonIndex: 5,
             showSeparators: true,
           },
           (index: number) => {
@@ -35,7 +36,6 @@ export const HomeScreenHeaderRight = () => {
               navigator.navigate('ImportWalletSeedPhrase');
             }
             if (index === 4) {
-              console.debug('watch called');
               navigator.navigate('ImportWalletWatch');
             }
           },

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -9,8 +9,8 @@ import { getAddressFormat } from '../utils/Wallet';
 interface Props {
   addressFrom: string;
   addressTo: string;
-  status: string;
-  amount: string;
+  status?: string;
+  amount: number;
   blockNumber?: string;
   sent?: boolean;
 }
@@ -28,6 +28,10 @@ export const TransactionCard = (props: Props) => {
   };
   const sentReceivedLabel = sent ? 'Sent' : 'Received';
   const address = sent ? addressTo : addressFrom;
+  const localStringOptions = {
+    maximumFractionDigits: 12,
+    minimumFractionDigits: 2,
+  };
   return (
     <Card style={styles.card}>
       <TouchableWithoutFeedback onPress={() => goDetailts(blockNumber)}>
@@ -38,7 +42,7 @@ export const TransactionCard = (props: Props) => {
           </View>
           <View>
             <Text style={[GlobalStyles.generalText, GlobalStyles.textBold, !sent && GlobalStyles.greenColor]}>
-              {sent ? '-' : '+'} {amount}
+              {sent ? '-' : '+'} {amount.toLocaleString('en-US', localStringOptions)}
             </Text>
             <Text style={GlobalStyles.textRight}>Fecha</Text>
           </View>

--- a/src/components/TransactionSection.tsx
+++ b/src/components/TransactionSection.tsx
@@ -1,6 +1,6 @@
 import GlobalStyles from '../constants/GlobalStyles';
 import React, { useEffect, useRef, useState } from 'react';
-import { StyleSheet, Text, View, ScrollView, Dimensions, SafeAreaView, FlatList } from 'react-native';
+import { SafeAreaView, FlatList } from 'react-native';
 
 import { TransactionSectionTop } from './TransactionSectionTop';
 import { getTransactionsByAddress } from '../services/AkromaApi';
@@ -8,10 +8,9 @@ import { TransactionCard } from './TransactionCard';
 import { Utils } from 'typesafe-web3/dist/lib/utils';
 import { WalletContext } from '../providers/WalletProvider';
 import { Divider } from '@ui-kitten/components';
-const screenHeight = Dimensions.get('window').height;
 
 export const TransactionSection = ({ setDisplayButtons }) => {
-  const { getTransactionCountByAddress, state } = React.useContext(WalletContext);
+  const { state } = React.useContext(WalletContext);
 
   const [transactions, setTransactions] = useState([]);
   const [page, setPage] = useState(1);
@@ -32,10 +31,7 @@ export const TransactionSection = ({ setDisplayButtons }) => {
   const loadMoreTransactions = () => {
     setPage(page + 1);
   };
-  const onViewableItemsChanged = ({ viewableItems, changed }) => {
-    console.log('Visible items are', viewableItems);
-    console.log('Changed in this iteration', changed);
-  };
+
   return (
     <SafeAreaView style={[GlobalStyles.walletsContainer]}>
       <TransactionSectionTop />
@@ -43,7 +39,7 @@ export const TransactionSection = ({ setDisplayButtons }) => {
         ref={listRef}
         keyExtractor={({ id }) => id}
         data={transactions}
-        renderItem={({ item }) => <TransactionCard addressFrom={item.from} amount={String(item.value * 0.000000000000000001)} addressTo={item.to} sent={item.from === sumAddress} />}
+        renderItem={({ item }) => <TransactionCard addressFrom={item.from} amount={item.value * 0.000000000000000001} addressTo={item.to} sent={item.from === sumAddress} />}
         onEndReached={loadMoreTransactions}
         ItemSeparatorComponent={() => <Divider />}
         onScrollBeginDrag={() => console.log('start')}
@@ -60,24 +56,3 @@ export const TransactionSection = ({ setDisplayButtons }) => {
     </SafeAreaView>
   );
 };
-
-const styles = StyleSheet.create({
-  walletsList: {
-    maxHeight: screenHeight - 206,
-    minHeight: screenHeight - 206,
-  },
-  walletsSection: {
-    paddingTop: 30,
-    textAlign: 'center',
-  },
-  subTitle: {
-    paddingHorizontal: 20,
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#1C1C1E',
-  },
-  container: {
-    height: '29%',
-    backgroundColor: 'red',
-  },
-});

--- a/src/components/WalletCard.tsx
+++ b/src/components/WalletCard.tsx
@@ -8,7 +8,10 @@ interface Params {
   wallet: WalletModel;
 }
 export const WalletCard = (params: Params) => {
-  console.log(params);
+  const localStringOptions = {
+    maximumFractionDigits: 12,
+    minimumFractionDigits: 2,
+  };
   return (
     <View style={[GlobalStyles.walletCard, GlobalStyles.flexRowBetween, GlobalStyles.ph24]}>
       <View>
@@ -16,7 +19,7 @@ export const WalletCard = (params: Params) => {
         <Text style={[GlobalStyles.smallText]}>{getAddressFormat(params.wallet.address)}</Text>
       </View>
       <View>
-        <Text style={[GlobalStyles.generalText, GlobalStyles.textBold]}>{params.wallet.lastBalance.toString()}</Text>
+        <Text style={[GlobalStyles.generalText, GlobalStyles.textBold]}>{params.wallet.lastBalance.toLocaleString('en-US', localStringOptions)}</Text>
       </View>
     </View>
   );

--- a/src/screens/home/CreateWalletScreen.tsx
+++ b/src/screens/home/CreateWalletScreen.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, SafeAreaView, Text, View } from 'react-native';
+import { ActivityIndicator, Keyboard, SafeAreaView, Text, TouchableWithoutFeedback, View } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { useContext, useState } from 'react';
 import { Avatar, Button, Input } from '@ui-kitten/components';
@@ -68,25 +68,27 @@ export const CreateWalletScreen = () => {
   };
 
   return (
-    <SafeAreaView style={GlobalStyles.flex}>
-      <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
-        <View style={GlobalStyles.logoContainer}>
-          <Avatar style={GlobalStyles.logoImage} source={require('../../assets/images/icon.png')} />
-        </View>
-        {loading ? (
-          <ActivityIndicator size="large" />
-        ) : (
-          <View style={GlobalStyles.container}>
-            <View>
-              <Input style={GlobalStyles.input} onChangeText={validateName} value={name} placeholder="Enter a Wallet name" disabled={loading} caption={renderCaption('Should contain at least 5 characters', !isNameValid)} />
-              <Input style={GlobalStyles.input} onChangeText={validatePin} value={pin} placeholder="Enter a Pin" disabled={loading} keyboardType="number-pad" caption={renderCaption('Should contain at least 4 numbers', !isPinValid)} />
-              <Button style={GlobalStyles.button} disabled={loading || invalid()} onPress={async () => await OnCreateWalletPress()}>
-                CREATE WALLET
-              </Button>
-            </View>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView style={GlobalStyles.flex}>
+        <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
+          <View style={GlobalStyles.logoContainer}>
+            <Avatar style={GlobalStyles.logoImage} source={require('../../assets/images/icon.png')} />
           </View>
-        )}
-      </ImageOverlay>
-    </SafeAreaView>
+          {loading ? (
+            <ActivityIndicator size="large" />
+          ) : (
+            <View style={GlobalStyles.container}>
+              <View>
+                <Input style={GlobalStyles.input} onChangeText={validateName} value={name} placeholder="Enter a Wallet name" disabled={loading} caption={renderCaption('Should contain at least 5 characters', !isNameValid)} />
+                <Input style={GlobalStyles.input} onChangeText={validatePin} value={pin} placeholder="Enter a Pin" disabled={loading} keyboardType="number-pad" caption={renderCaption('Should contain at least 4 numbers', !isPinValid)} />
+                <Button style={GlobalStyles.button} disabled={loading || invalid()} onPress={async () => await OnCreateWalletPress()}>
+                  CREATE WALLET
+                </Button>
+              </View>
+            </View>
+          )}
+        </ImageOverlay>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/screens/home/ImportWalletKeystore.tsx
+++ b/src/screens/home/ImportWalletKeystore.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, Platform, SafeAreaView, View } from 'react-native';
+import { ActivityIndicator, Keyboard, Platform, SafeAreaView, TouchableWithoutFeedback, View } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { useState } from 'react';
 import { Button, Input } from '@ui-kitten/components';
@@ -110,36 +110,38 @@ export const ImportWalletKeystore = () => {
     }
   };
   return (
-    <SafeAreaView style={GlobalStyles.flex}>
-      <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
-        {loading ? (
-          <ActivityIndicator size="large" />
-        ) : (
-          <View style={GlobalStyles.container}>
-            <View>
-              <Input style={GlobalStyles.input} onChangeText={setName} value={name} placeholder="Wallet name, min 5 chars" disabled={loading} />
-              <Input style={GlobalStyles.input} onChangeText={walletPasswordChange} value={walletPassword} placeholder="Current Wallet Password" disabled={loading} />
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView style={GlobalStyles.flex}>
+        <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
+          {loading ? (
+            <ActivityIndicator size="large" />
+          ) : (
+            <View style={GlobalStyles.container}>
+              <View>
+                <Input style={GlobalStyles.input} onChangeText={setName} value={name} placeholder="Wallet name, min 5 chars" disabled={loading} />
+                <Input style={GlobalStyles.input} onChangeText={walletPasswordChange} value={walletPassword} placeholder="Current Wallet Password" disabled={loading} />
 
-              <Input multiline={true} style={GlobalStyles.button} value={walletJson} numberOfLines={14} placeholder="Wallet JSON" disabled={true} />
+                <Input multiline={true} style={GlobalStyles.button} value={walletJson} numberOfLines={14} placeholder="Wallet JSON" disabled={true} />
 
-              {loading ? (
-                <ActivityIndicator size="large" />
-              ) : (
-                <View>
-                  <View style={GlobalStyles.input}>
-                    <Button style={GlobalStyles.input} onPress={async () => await loadJson()}>
-                      Load JSON
+                {loading ? (
+                  <ActivityIndicator size="large" />
+                ) : (
+                  <View>
+                    <View style={GlobalStyles.input}>
+                      <Button style={GlobalStyles.input} onPress={async () => await loadJson()}>
+                        Load JSON
+                      </Button>
+                    </View>
+                    <Button disabled={loading || invalid()} onPress={async () => await OnImportPress()}>
+                      IMPORT
                     </Button>
                   </View>
-                  <Button disabled={loading || invalid()} onPress={async () => await OnImportPress()}>
-                    IMPORT
-                  </Button>
-                </View>
-              )}
+                )}
+              </View>
             </View>
-          </View>
-        )}
-      </ImageOverlay>
-    </SafeAreaView>
+          )}
+        </ImageOverlay>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };

--- a/src/screens/home/ImportWalletWatch.tsx
+++ b/src/screens/home/ImportWalletWatch.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, SafeAreaView, View } from 'react-native';
+import { ActivityIndicator, Keyboard, SafeAreaView, TouchableWithoutFeedback, View } from 'react-native';
 import GlobalStyles from '../../constants/GlobalStyles';
 import { useState, useContext, useEffect } from 'react';
 import { Button, Input } from '@ui-kitten/components';
@@ -59,22 +59,24 @@ export const ImportWalletWatch = () => {
   };
 
   return (
-    <SafeAreaView style={GlobalStyles.flex}>
-      <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
-        {loading ? (
-          <ActivityIndicator size="large" />
-        ) : (
-          <View style={GlobalStyles.container}>
-            <View>
-              <Input style={GlobalStyles.input} onChangeText={setName} value={name} placeholder="Wallet name, min 5 chars" disabled={loading} />
-              <Input style={GlobalStyles.input} onChangeText={walletAddressChange} value={walletAddress} placeholder="Wallet Address" disabled={loading} />
-              <Button disabled={loading} onPress={async () => await OnImportPress()}>
-                IMPORT
-              </Button>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+      <SafeAreaView style={GlobalStyles.flex}>
+        <ImageOverlay style={GlobalStyles.container} source={require('../../assets/images/background.png')}>
+          {loading ? (
+            <ActivityIndicator size="large" />
+          ) : (
+            <View style={GlobalStyles.container}>
+              <View>
+                <Input style={GlobalStyles.input} onChangeText={setName} value={name} placeholder="Wallet name, min 5 chars" disabled={loading} />
+                <Input style={GlobalStyles.input} onChangeText={walletAddressChange} value={walletAddress} placeholder="Wallet Address" disabled={loading} />
+                <Button disabled={loading} onPress={async () => await OnImportPress()}>
+                  IMPORT
+                </Button>
+              </View>
             </View>
-          </View>
-        )}
-      </ImageOverlay>
-    </SafeAreaView>
+          )}
+        </ImageOverlay>
+      </SafeAreaView>
+    </TouchableWithoutFeedback>
   );
 };


### PR DESCRIPTION
[Issue-152](https://github.com/akroma-project/akroma-wallet-mobile/issues/152)

## Only on iOS

#### Describe the solution
- Keyboard

  - The keyboard can't hide on iOS, just pressing return.
- popup options

  - Currently don't exist a way to dismiss the popup on iOS.
  - Press outside don't works.

#### How to test
- Keyboard
1. Go to create wallet or import keystone or watch wallet.
2. Press any input.
3. Press out of keyboard.

- Popup
1. Open options.
2. Press Cancel.

## Additional Comments
I added format to the balance on transaction card and wallet card

## Closes
clases #152 