### PR TITLE
fix: remove splash when the app starts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,9 @@ const App = () => {
   const [isAppReady, setIsAppReady] = useState(false);
 
   useEffect(() => {
-    setIsAppReady(true);
+    setTimeout(() => {
+      setIsAppReady(true);
+    }, 3000);
   }, []);
 
   return (
@@ -29,8 +31,8 @@ const App = () => {
             <IconRegistry icons={EvaIconsPack} />
             <ActionSheetProvider>
               <WalletProvider>
-                <ApplicationNavigation />
                 <Toast />
+                <ApplicationNavigation />
               </WalletProvider>
             </ActionSheetProvider>
           </ApplicationProvider>

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -3,13 +3,8 @@ import { Animated, StyleSheet } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
 export function WithSplashScreen({ children, isAppReady }: { isAppReady: boolean; children: React.ReactNode }) {
-  return (
-    <>
-      {isAppReady && children}
-
-      <Splash isAppReady={isAppReady} />
-    </>
-  );
+  const content = isAppReady ? children : <Splash isAppReady={isAppReady} />;
+  return <>{content}</>;
 }
 
 const LOADING_IMAGE = 'Loading image';

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -7,7 +7,6 @@ import { WalletContext } from '../../providers/WalletProvider';
 import { TopWallets } from '../../components/TopWallets';
 import { useDatabaseConnection } from '../../data/connection';
 import MainLayout from '../../layout/MainLayout';
-
 export const HomeScreen = () => {
   const { isConnected } = useDatabaseConnection();
 
@@ -50,7 +49,6 @@ export const HomeScreen = () => {
       await refreshWallets();
       await loadWallets();
     })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnected]);
   return (
     <MainLayout>


### PR DESCRIPTION
## Describe the solution
<!-- Required -->
- [x] Remove the splash screen when the app is started. The splashscreen were blocking the touch on options (triple dots)

## How to test
<!-- Required -->
1. Start the app
2. wait for splash screen
3. Once the splashcreen is completed. Tap over the triple dots
4. It should display the modal with options

**Note**: The main focus for this card is duplicated on the issue. This PR only solve a bug
- #168 

## Closes
<!--
add the issues to close when the PR is merged. For example:

- #123
- #325
-->
- #129 